### PR TITLE
results of running npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,323 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@ciscospark/common": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/common/-/common-1.32.23.tgz",
+      "integrity": "sha1-Z42nujRy55QLJuzqvALTEeCoof0=",
+      "requires": {
+        "babel-runtime": "^6.23.0",
+        "backoff": "^2.5.0",
+        "core-decorators": "^0.20.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.4",
+        "urlsafe-base64": "^1.0.0"
+      }
+    },
+    "@ciscospark/common-evented": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/common-evented/-/common-evented-1.32.23.tgz",
+      "integrity": "sha1-yFUrujAlT2gTO6sXCwxfUYG3zH8=",
+      "requires": {
+        "@ciscospark/common": "1.32.23",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@ciscospark/common-timers": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/common-timers/-/common-timers-1.32.23.tgz",
+      "integrity": "sha1-xB7qYS5h7m7RJO/sRz+BnOKaLnY=",
+      "requires": {
+        "envify": "^4.1.0"
+      }
+    },
+    "@ciscospark/http-core": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/http-core/-/http-core-1.32.23.tgz",
+      "integrity": "sha1-Ak5NGxXtc7Dtjkmogj3RNHtv8cs=",
+      "requires": {
+        "@ciscospark/common": "1.32.23",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "file-type": "^3.9.0",
+        "global": "^4.3.1",
+        "is-function": "^1.0.1",
+        "lodash": "^4.17.4",
+        "parse-headers": "^2.0.1",
+        "qs": "^6.5.1",
+        "request": "^2.81.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "@ciscospark/internal-plugin-feature": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-feature/-/internal-plugin-feature-1.32.23.tgz",
+      "integrity": "sha1-Sni0V2TLrywNsVPgdYkmOUnRIeo=",
+      "requires": {
+        "@ciscospark/internal-plugin-wdm": "1.32.23",
+        "@ciscospark/spark-core": "1.32.23",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "@ciscospark/internal-plugin-locus": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-locus/-/internal-plugin-locus-1.32.23.tgz",
+      "integrity": "sha1-30NLVkILow1W3gGgvFcHfiVLRf8=",
+      "requires": {
+        "@ciscospark/internal-plugin-mercury": "1.32.23",
+        "@ciscospark/spark-core": "1.32.23",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.4",
+        "uuid": "^3.2.1"
+      }
+    },
+    "@ciscospark/internal-plugin-mercury": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-mercury/-/internal-plugin-mercury-1.32.23.tgz",
+      "integrity": "sha1-ppNtAk5fegUx7hXRsasXeD6maBA=",
+      "requires": {
+        "@ciscospark/common": "1.32.23",
+        "@ciscospark/common-timers": "1.32.23",
+        "@ciscospark/internal-plugin-feature": "1.32.23",
+        "@ciscospark/internal-plugin-metrics": "1.32.23",
+        "@ciscospark/internal-plugin-wdm": "1.32.23",
+        "@ciscospark/spark-core": "1.32.23",
+        "babel-runtime": "^6.23.0",
+        "backoff": "^2.5.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.4",
+        "uuid": "^3.2.1",
+        "ws": "^4.0.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "4.1.0",
+          "resolved": "http://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "@ciscospark/internal-plugin-metrics": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-metrics/-/internal-plugin-metrics-1.32.23.tgz",
+      "integrity": "sha1-ouM/8dua59XwBsgFaOM7I9bK3zY=",
+      "requires": {
+        "@ciscospark/common": "1.32.23",
+        "@ciscospark/common-timers": "1.32.23",
+        "@ciscospark/internal-plugin-wdm": "1.32.23",
+        "@ciscospark/spark-core": "1.32.23",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@ciscospark/internal-plugin-wdm": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-wdm/-/internal-plugin-wdm-1.32.23.tgz",
+      "integrity": "sha1-6fiimAoVx4bDXgW1J0SEJ4GBxfk=",
+      "requires": {
+        "@ciscospark/common": "1.32.23",
+        "@ciscospark/common-timers": "1.32.23",
+        "@ciscospark/http-core": "1.32.23",
+        "@ciscospark/spark-core": "1.32.23",
+        "ampersand-collection": "^2.0.2",
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "@ciscospark/media-engine-webrtc": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/media-engine-webrtc/-/media-engine-webrtc-1.32.23.tgz",
+      "integrity": "sha1-O9Eg2hnIl2N8hrx1mpnPvZ89/4A=",
+      "requires": {
+        "@ciscospark/common": "1.32.23",
+        "@ciscospark/common-evented": "1.32.23",
+        "ampersand-events": "^2.0.2",
+        "babel-runtime": "^6.23.0",
+        "bowser": "^1.6.0",
+        "core-decorators": "^0.20.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.4",
+        "lodash-decorators": "^4.3.4",
+        "sdp-transform": "^2.4.0",
+        "webrtc-adapter": "^6.1.0"
+      }
+    },
+    "@ciscospark/plugin-authorization": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-authorization/-/plugin-authorization-1.32.23.tgz",
+      "integrity": "sha1-EgVk9NpwxW5Uyql/rehNGfMj340=",
+      "requires": {
+        "@ciscospark/plugin-authorization-browser": "1.32.23",
+        "@ciscospark/plugin-authorization-node": "1.32.23",
+        "envify": "^4.1.0"
+      }
+    },
+    "@ciscospark/plugin-authorization-browser": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-authorization-browser/-/plugin-authorization-browser-1.32.23.tgz",
+      "integrity": "sha1-AawbHvzEu8AN6pY4ElgI/rotsVw=",
+      "requires": {
+        "@ciscospark/common": "1.32.23",
+        "@ciscospark/internal-plugin-wdm": "1.32.23",
+        "@ciscospark/spark-core": "1.32.23",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.4",
+        "uuid": "^3.2.1"
+      }
+    },
+    "@ciscospark/plugin-authorization-node": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-authorization-node/-/plugin-authorization-node-1.32.23.tgz",
+      "integrity": "sha1-bbC0hVTaTd1j8DimDb3pouTyvvw=",
+      "requires": {
+        "@ciscospark/common": "1.32.23",
+        "@ciscospark/internal-plugin-wdm": "1.32.23",
+        "@ciscospark/spark-core": "1.32.23",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@ciscospark/plugin-logger": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-logger/-/plugin-logger-1.32.23.tgz",
+      "integrity": "sha1-with7ce3khtqJcE4I+yBBJUZtCg=",
+      "requires": {
+        "@ciscospark/common": "1.32.23",
+        "@ciscospark/spark-core": "1.32.23",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "@ciscospark/plugin-memberships": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-memberships/-/plugin-memberships-1.32.23.tgz",
+      "integrity": "sha1-LnhOSAxozq5dljKu+CIkgqGrPEc=",
+      "requires": {
+        "@ciscospark/spark-core": "1.32.23",
+        "envify": "^4.1.0"
+      }
+    },
+    "@ciscospark/plugin-messages": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-messages/-/plugin-messages-1.32.23.tgz",
+      "integrity": "sha1-xCQN7Ewh/uxlSPujemnKSxN8w+U=",
+      "requires": {
+        "@ciscospark/spark-core": "1.32.23",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "@ciscospark/plugin-people": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-people/-/plugin-people-1.32.23.tgz",
+      "integrity": "sha1-5hy90mlkurczdfICOQS1O20C0fo=",
+      "requires": {
+        "@ciscospark/common": "1.32.23",
+        "@ciscospark/spark-core": "1.32.23",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@ciscospark/plugin-phone": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-phone/-/plugin-phone-1.32.23.tgz",
+      "integrity": "sha1-TdCA2mlHLuPAYEPn8shpZcZ6gjc=",
+      "requires": {
+        "@ciscospark/common": "1.32.23",
+        "@ciscospark/common-timers": "1.32.23",
+        "@ciscospark/internal-plugin-locus": "1.32.23",
+        "@ciscospark/internal-plugin-metrics": "1.32.23",
+        "@ciscospark/media-engine-webrtc": "1.32.23",
+        "@ciscospark/plugin-people": "1.32.23",
+        "@ciscospark/spark-core": "1.32.23",
+        "ampersand-collection": "^2.0.2",
+        "ampersand-collection-lodash-mixin": "^4.0.0",
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "detectrtc": "^1.3.4",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.4",
+        "lodash-decorators": "^4.3.4",
+        "sdp-transform": "^2.4.0",
+        "uuid": "^3.2.1"
+      }
+    },
+    "@ciscospark/plugin-rooms": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-rooms/-/plugin-rooms-1.32.23.tgz",
+      "integrity": "sha1-hGpv+DZa/nh45v83WBLNEdEfM10=",
+      "requires": {
+        "@ciscospark/spark-core": "1.32.23",
+        "envify": "^4.1.0"
+      }
+    },
+    "@ciscospark/plugin-team-memberships": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-team-memberships/-/plugin-team-memberships-1.32.23.tgz",
+      "integrity": "sha1-ZKCtWn6utOT8I3G2F8/Frg3gyAg=",
+      "requires": {
+        "@ciscospark/spark-core": "1.32.23",
+        "envify": "^4.1.0"
+      }
+    },
+    "@ciscospark/plugin-teams": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-teams/-/plugin-teams-1.32.23.tgz",
+      "integrity": "sha1-VLP5egI2iiv9VP3SjGIWBpUlFmI=",
+      "requires": {
+        "@ciscospark/spark-core": "1.32.23",
+        "envify": "^4.1.0"
+      }
+    },
+    "@ciscospark/plugin-webhooks": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-webhooks/-/plugin-webhooks-1.32.23.tgz",
+      "integrity": "sha1-bRAsA9Nf1MHWzwwHYdIImHndu3E=",
+      "requires": {
+        "@ciscospark/spark-core": "1.32.23",
+        "envify": "^4.1.0"
+      }
+    },
+    "@ciscospark/spark-core": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/spark-core/-/spark-core-1.32.23.tgz",
+      "integrity": "sha1-hrdSNpl7XsXGKVkpPDRucyWknrk=",
+      "requires": {
+        "@ciscospark/common": "1.32.23",
+        "@ciscospark/common-timers": "1.32.23",
+        "@ciscospark/http-core": "1.32.23",
+        "ampersand-collection": "^2.0.2",
+        "ampersand-events": "^2.0.2",
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.4",
+        "uuid": "^3.2.1"
+      }
+    },
+    "@ciscospark/storage-adapter-local-storage": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/@ciscospark/storage-adapter-local-storage/-/storage-adapter-local-storage-1.32.23.tgz",
+      "integrity": "sha1-tZH36p2ySfpn5D8U8n7v8MYQnws=",
+      "requires": {
+        "@ciscospark/spark-core": "1.32.23",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
     "@types/async": {
       "version": "2.0.50",
       "resolved": "https://registry.npmjs.org/@types/async/-/async-2.0.50.tgz",
@@ -83,9 +400,9 @@
       "integrity": "sha512-M3HHoXXndsho/sTbQML2BJr7/uwNhMg8P0D4lb+UsM65JQZx268faiz9hKpY4FpocWqpwlLwa8vevw8hLtKjOw=="
     },
     "@types/range-parser": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.2.tgz",
-      "integrity": "sha512-HtKGu+qG1NPvYe1z7ezLsyIaXYyi8SoAVqWDZgDQ8dLrsZvSzUNCwZyfX33uhWxL/SU0ZDQZ3nwZ0nimt507Kw=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/request": {
       "version": "2.48.1",
@@ -122,6 +439,30 @@
       "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-0.8.2.tgz",
       "integrity": "sha1-EYHsvh2XtwNODqHjXmLobMJrQi0="
     },
+    "@xmpp/jid": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@xmpp/jid/-/jid-0.0.2.tgz",
+      "integrity": "sha1-DVKMqdWNr8gzZlVk/+YvMyoxZ/I="
+    },
+    "@xmpp/streamparser": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@xmpp/streamparser/-/streamparser-0.0.6.tgz",
+      "integrity": "sha1-EYAz6p23yGoctGED8mnr/3n28eo=",
+      "requires": {
+        "@xmpp/xml": "^0.1.3",
+        "inherits": "^2.0.3",
+        "ltx": "^2.5.0"
+      }
+    },
+    "@xmpp/xml": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@xmpp/xml/-/xml-0.1.3.tgz",
+      "integrity": "sha1-HxQ5nlPkGWiFWGmPbGLnHjmoam4=",
+      "requires": {
+        "inherits": "^2.0.3",
+        "ltx": "^2.6.2"
+      }
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -132,12 +473,11 @@
       }
     },
     "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "requires": {
-        "extend": "~3.0.0",
-        "semver": "~5.0.1"
+        "es6-promisify": "^5.0.0"
       }
     },
     "ajv": {
@@ -151,22 +491,92 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ampersand-class-extend": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ampersand-class-extend/-/ampersand-class-extend-2.0.0.tgz",
+      "integrity": "sha1-Uolf+lkhdjSmGI/RhLEEj12Aiv8=",
+      "requires": {
+        "lodash": "^4.11.1"
+      }
+    },
+    "ampersand-collection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ampersand-collection/-/ampersand-collection-2.0.2.tgz",
+      "integrity": "sha512-IjDa4HTL/tdQDDL0SGyWk4AHD02iNtUSLRWkAsJ2biPvapljW9HNgIEIdbPnnR+7Gb9BJkjesaLNjVZfAMzeuA==",
+      "requires": {
+        "ampersand-class-extend": "^2.0.0",
+        "ampersand-events": "^2.0.1",
+        "ampersand-version": "^1.0.2",
+        "lodash": "^4.11.1"
+      }
+    },
+    "ampersand-collection-lodash-mixin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ampersand-collection-lodash-mixin/-/ampersand-collection-lodash-mixin-4.0.0.tgz",
+      "integrity": "sha1-DtBHqOc8sHC8NrZ4pGPjgqyNtt0=",
+      "requires": {
+        "ampersand-version": "^1.0.0",
+        "lodash": "^4.6.1"
+      }
+    },
+    "ampersand-events": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-2.0.2.tgz",
+      "integrity": "sha1-9AK8LhgwX6vZldvc07cFe73X00c=",
+      "requires": {
+        "ampersand-version": "^1.0.2",
+        "lodash": "^4.6.1"
+      }
+    },
+    "ampersand-state": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-5.0.3.tgz",
+      "integrity": "sha512-sr904K5zvw6mkGjFHhTcfBIdpoJ6mn/HrFg7OleRmBpw3apLb3Z0gVrgRTb7kK1wOLI34vs4S+IXqNHUeqWCzw==",
+      "requires": {
+        "ampersand-events": "^2.0.1",
+        "ampersand-version": "^1.0.0",
+        "array-next": "~0.0.1",
+        "key-tree-store": "^1.3.0",
+        "lodash": "^4.12.0"
+      }
+    },
+    "ampersand-version": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ampersand-version/-/ampersand-version-1.0.2.tgz",
+      "integrity": "sha1-/489TOrE0yzNg/a9Zpc5f3tZ4sA=",
+      "requires": {
+        "find-root": "^0.1.1",
+        "through2": "^0.6.3"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argv-tools": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
+      "integrity": "sha512-Cc0dBvx4dvrjjKpyDA6w8RlNAw8Su30NvZbWl/Tv9ZALEVlLVkWQiHMi84Q0xNfpVuSaiQbYkdmWK8g1PLGhKw==",
+      "requires": {
+        "array-back": "^2.0.0",
+        "find-replace": "^2.0.1"
+      }
     },
     "array-back": {
-      "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-      "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
       "requires": {
-        "typical": "^2.6.0"
+        "typical": "^2.6.1"
       }
     },
     "array-flatten": {
@@ -174,10 +584,10 @@
       "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
-    "array-uniq": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-      "integrity": "sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0="
+    "array-next": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-next/-/array-next-0.0.1.tgz",
+      "integrity": "sha1-5eRmCkwn/agVH/d2QnXQCQAGK+E="
     },
     "asap": {
       "version": "2.0.6",
@@ -211,6 +621,11 @@
         "lodash": "^4.17.10"
       }
     },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -227,12 +642,38 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "version": "0.18.0",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
-        "follow-redirects": "^1.2.5",
+        "follow-redirects": "^1.3.0",
         "is-buffer": "^1.1.5"
+      }
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "back": {
@@ -241,6 +682,14 @@
       "integrity": "sha1-qT9ebOaXKZhNWQGiuxbjsBpNY2k=",
       "requires": {
         "xtend": "^4.0.0"
+      }
+    },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "requires": {
+        "precond": "0.2"
       }
     },
     "balanced-match": {
@@ -262,14 +711,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bl": {
-      "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
-      "requires": {
-        "readable-stream": "~2.0.5"
-      }
-    },
     "body-parser": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
@@ -285,14 +726,16 @@
         "qs": "6.5.2",
         "raw-body": "2.3.3",
         "type-is": "~1.6.16"
-      }
-    },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "requires": {
-        "hoek": "2.x.x"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "botbuilder": {
@@ -327,30 +770,36 @@
       }
     },
     "botkit": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/botkit/-/botkit-0.4.10.tgz",
-      "integrity": "sha1-9v8msVSWqwhz4MoPZztPNNmOtEM=",
+      "version": "0.6.21",
+      "resolved": "https://registry.npmjs.org/botkit/-/botkit-0.6.21.tgz",
+      "integrity": "sha512-oAHpHrmc3ir384Id0cXWNZ/+MQ6g6e0YYQZanw6nYd5zoqf0tqY40HsEw9gmMOLA3pcYGl6wD8h0pfjJWqc6sg==",
       "requires": {
-        "async": "^2.0.0-rc.5",
-        "back": "^1.0.1",
-        "body-parser": "^1.14.2",
-        "botbuilder": "^3.2.3",
-        "botkit-studio-sdk": "^1.0.0",
-        "clone": "2.0.0",
-        "command-line-args": "^3.0.0",
-        "crypto": "0.0.3",
-        "express": "^4.13.3",
-        "https-proxy-agent": "^1.0.0",
-        "jfs": "^0.2.6",
-        "localtunnel": "^1.8.1",
-        "md5": "^2.1.0",
-        "mustache": "^2.2.1",
-        "promise": "^7.1.1",
-        "randomstring": "^1.1.5",
-        "request": "^2.67.0",
-        "twilio": "^2.9.1",
+        "async": "^2.6.1",
+        "back": "^1.0.2",
+        "body-parser": "^1.18.3",
+        "botbuilder": "^3.15.0",
+        "botkit-studio-sdk": "^1.0.8",
+        "chalk": "^2.4.1",
+        "ciscospark": "^1.32.23",
+        "clone": "2.1.2",
+        "command-line-args": "^5.0.2",
+        "command-line-usage": "^5.0.5",
+        "debug": "^4.1.0",
+        "email-addresses": "^3.0.2",
+        "express": "^4.16.4",
+        "googleapis": "^34.0.0",
+        "https-proxy-agent": "^2.2.1",
+        "jfs": "^0.3.0",
+        "localtunnel": "^1.9.1",
+        "md5": "^2.2.1",
+        "mustache": "^3.0.0",
+        "prompts": "^1.1.1",
+        "request": "^2.81.0",
+        "requestretry": "^3.0.2",
+        "simple-xmpp": "^1.3.0",
+        "twilio": "^3.23.1",
         "ware": "^1.3.0",
-        "ws": "^1.1.1"
+        "ws": "^6.1.0"
       }
     },
     "botkit-studio-sdk": {
@@ -372,6 +821,11 @@
         }
       }
     },
+    "bowser": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
+      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -381,6 +835,11 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "browser-request": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
+      "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -428,21 +887,27 @@
       }
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
         "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -465,6 +930,29 @@
         "moment": "^2.10.3"
       }
     },
+    "ciscospark": {
+      "version": "1.32.23",
+      "resolved": "https://registry.npmjs.org/ciscospark/-/ciscospark-1.32.23.tgz",
+      "integrity": "sha1-uP3+EqOXIL1ZzIAJV+au5bmc7No=",
+      "requires": {
+        "@ciscospark/internal-plugin-wdm": "1.32.23",
+        "@ciscospark/plugin-authorization": "1.32.23",
+        "@ciscospark/plugin-logger": "1.32.23",
+        "@ciscospark/plugin-memberships": "1.32.23",
+        "@ciscospark/plugin-messages": "1.32.23",
+        "@ciscospark/plugin-people": "1.32.23",
+        "@ciscospark/plugin-phone": "1.32.23",
+        "@ciscospark/plugin-rooms": "1.32.23",
+        "@ciscospark/plugin-team-memberships": "1.32.23",
+        "@ciscospark/plugin-teams": "1.32.23",
+        "@ciscospark/plugin-webhooks": "1.32.23",
+        "@ciscospark/spark-core": "1.32.23",
+        "@ciscospark/storage-adapter-local-storage": "1.32.23",
+        "babel-polyfill": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.4"
+      }
+    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -476,9 +964,9 @@
       }
     },
     "clone": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.0.0.tgz",
-      "integrity": "sha1-32XTyhQuSkpH2zPaNGjQiKFvx24="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "co": {
       "version": "3.1.0",
@@ -490,6 +978,19 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
     "combined-stream": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
@@ -499,20 +1000,33 @@
       }
     },
     "command-line-args": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.5.tgz",
-      "integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.2.tgz",
+      "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
       "requires": {
-        "array-back": "^1.0.4",
-        "feature-detect-es6": "^1.3.1",
-        "find-replace": "^1.0.2",
-        "typical": "^2.6.0"
+        "argv-tools": "^0.1.1",
+        "array-back": "^2.0.0",
+        "find-replace": "^2.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^2.6.1"
+      }
+    },
+    "command-line-usage": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.5.tgz",
+      "integrity": "sha512-d8NrGylA5oCXSbGoKz05FkehDAzSmIm4K03S5VDh4d5lZAtTWfc3D1RuETtuQCn8129nYfJfDdF7P/lwcz1BlA==",
+      "requires": {
+        "array-back": "^2.0.0",
+        "chalk": "^2.4.1",
+        "table-layout": "^0.4.3",
+        "typical": "^2.6.1"
       }
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
       "requires": {
         "graceful-readlink": ">= 1.0.0"
       }
@@ -543,6 +1057,16 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "core-decorators": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.20.0.tgz",
+      "integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU="
+    },
+    "core-js": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
+      "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -553,19 +1077,6 @@
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "requires": {
-        "boom": "2.x.x"
-      }
-    },
-    "crypto": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz",
-      "integrity": "sha1-RwqBuGvkxe4XrMggeh9TFa4g27A="
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -575,11 +1086,18 @@
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+      "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "decamelize": {
@@ -596,6 +1114,11 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -607,20 +1130,30 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "deprecate": {
-      "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/deprecate/-/deprecate-0.1.0.tgz",
-      "integrity": "sha1-xJBYYS3GyOUUXq/kg5uMLH0EHBQ="
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/deprecate/-/deprecate-1.0.0.tgz",
+      "integrity": "sha1-ZhSQ7SQokWpsiIPYg05WRvTkpKg="
     },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "detectrtc": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/detectrtc/-/detectrtc-1.3.7.tgz",
+      "integrity": "sha512-eniu45rJNjF95QdU19wVjiwnQEZjY2fKLyeTNUVFfSiQplBIP0No8v75X25/wUnIfIQB/ymaVMAfrB3WIYta8Q=="
+    },
     "diff": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
+    },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "dotenv": {
       "version": "6.2.0",
@@ -649,10 +1182,24 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "email-addresses": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.0.3.tgz",
+      "integrity": "sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg=="
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "envify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/envify/-/envify-4.1.0.tgz",
+      "integrity": "sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==",
+      "requires": {
+        "esprima": "^4.0.0",
+        "through": "~2.3.4"
+      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -660,6 +1207,19 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
       }
     },
     "escape-html": {
@@ -671,6 +1231,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "etag": {
       "version": "1.8.1",
@@ -714,6 +1279,14 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -741,13 +1314,10 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
-    "feature-detect-es6": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.5.0.tgz",
-      "integrity": "sha512-DzWPIGzTnfp3/KK1d/YPfmgLqeDju9F2DQYBL35VusgSApcA7XGqVtXfR4ETOOFEzdFJ3J7zh0Gkk011TiA4uQ==",
-      "requires": {
-        "array-back": "^1.0.4"
-      }
+    "file-type": {
+      "version": "3.9.0",
+      "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
     },
     "finalhandler": {
       "version": "1.1.1",
@@ -763,6 +1333,14 @@
         "unpipe": "~1.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -771,13 +1349,18 @@
       }
     },
     "find-replace": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-      "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
+      "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
       "requires": {
-        "array-back": "^1.0.4",
-        "test-value": "^2.1.0"
+        "array-back": "^2.0.0",
+        "test-value": "^3.0.0"
       }
+    },
+    "find-root": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz",
+      "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE="
     },
     "find-up": {
       "version": "1.1.2",
@@ -804,6 +1387,14 @@
             "ms": "2.0.0"
           }
         }
+      }
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
       }
     },
     "forever-agent": {
@@ -837,20 +1428,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "generate-function": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+    "gcp-metadata": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.7.0.tgz",
+      "integrity": "sha512-ffjC09amcDWjh3VZdkDngIo7WoluyC5Ag9PAYxZbmQLOLNI8lvPtoKTSCyU54j2gwy5roZh6sSMTfkY2ct7K3g==",
       "requires": {
-        "is-property": "^1.0.2"
-      }
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "requires": {
-        "is-property": "^1.0.0"
+        "axios": "^0.18.0",
+        "extend": "^3.0.1",
+        "retry-axios": "0.3.2"
       }
     },
     "get-caller-file": {
@@ -886,6 +1471,68 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
+      }
+    },
+    "google-auth-library": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-2.0.1.tgz",
+      "integrity": "sha512-CWLKZxqYw4SE+fE3GWbVT9r/10h75w8lB3cdmmLpLtCfccFDcsI84qI5rx7npemlrHtKJh3C2HUz4s6SihCeIQ==",
+      "requires": {
+        "axios": "^0.18.0",
+        "gcp-metadata": "^0.7.0",
+        "gtoken": "^2.3.0",
+        "https-proxy-agent": "^2.2.1",
+        "jws": "^3.1.5",
+        "lodash.isstring": "^4.0.1",
+        "lru-cache": "^4.1.3",
+        "semver": "^5.5.0"
+      }
+    },
+    "google-p12-pem": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.3.tgz",
+      "integrity": "sha512-KGnAiMMWaJp4j4tYVvAjfP3wCKZRLv9M1Nir2wRRNWUYO7j1aX8O9Qgz+a8/EQ5rAvuo4SIu79n6SIdkNl7Msg==",
+      "requires": {
+        "node-forge": "^0.7.5",
+        "pify": "^4.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        }
+      }
+    },
+    "googleapis": {
+      "version": "34.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-34.0.0.tgz",
+      "integrity": "sha512-nGfTSrlQF77HDNOHDy0ii3ET1h8Yap6QXxkfMZsre+7hBg91g4RsgrA50BgrOXpbNlQCBOGXWhUsa267kVeA/Q==",
+      "requires": {
+        "google-auth-library": "^2.0.0",
+        "googleapis-common": "^0.3.0"
+      }
+    },
+    "googleapis-common": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-0.3.0.tgz",
+      "integrity": "sha512-OqQ2iskzjPHLoM+AXk7e/TmEsdgxyAk8PVbMg0S8v2wPhgMu2wTawEL7zH9QG236u/RqQ1Ak120oSWsamPnWGg==",
+      "requires": {
+        "axios": "^0.18.0",
+        "google-auth-library": "^2.0.0",
+        "pify": "^3.0.0",
+        "qs": "^6.5.2",
+        "url-template": "^2.0.8",
+        "uuid": "^3.2.1"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
@@ -894,13 +1541,33 @@
     "graceful-readlink": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
     },
     "growl": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
+    },
+    "gtoken": {
+      "version": "2.3.0",
+      "resolved": "http://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
+      "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
+      "requires": {
+        "axios": "^0.18.0",
+        "google-p12-pem": "^1.0.0",
+        "jws": "^3.1.4",
+        "mime": "^2.2.0",
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+          "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
+        }
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -916,29 +1583,19 @@
         "har-schema": "^2.0.0"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
     "has-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "http://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "he": {
@@ -979,13 +1636,27 @@
       }
     },
     "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "iconv-lite": {
@@ -1039,6 +1710,11 @@
         "builtin-modules": "^1.0.0"
       }
     },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -1047,27 +1723,10 @@
         "number-is-nan": "^1.0.0"
       }
     },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
-    },
-    "is-my-json-valid": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
-      "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1080,9 +1739,9 @@
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isemail": {
       "version": "1.2.0",
@@ -1095,30 +1754,23 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jfs": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/jfs/-/jfs-0.2.6.tgz",
-      "integrity": "sha1-hRtyjuXP9EmFXPmtVU9KXhSraRI=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/jfs/-/jfs-0.3.0.tgz",
+      "integrity": "sha1-WrzkRkOw0NLZUWQ5aGjyK7FViwQ=",
       "requires": {
-        "async": "~1.2.1",
-        "clone": "~1.0.2",
+        "async": "~2.5.0",
+        "clone": "~2.1.1",
         "mkdirp": "~0.5.1",
-        "node-uuid": "~1.4.3"
+        "uuid": "^3.1.0"
       },
       "dependencies": {
         "async": {
-          "version": "1.2.1",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.2.1.tgz",
-          "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA="
-        },
-        "clone": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "requires": {
+            "lodash": "^4.14.0"
+          }
         }
       }
     },
@@ -1158,11 +1810,6 @@
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsonwebtoken": {
       "version": "7.4.3",
@@ -1206,6 +1853,16 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "key-tree-store": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/key-tree-store/-/key-tree-store-1.3.0.tgz",
+      "integrity": "sha1-XqKa/CUppCWThDfWlVtxTOapeR8="
+    },
+    "kleur": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.1.tgz",
+      "integrity": "sha512-P3kRv+B+Ra070ng2VKQqW4qW7gd/v3iD8sy/zOdcYRsfiD+QBokQNOps/AfP6Hr48cBhIIBFWckB9aO+IZhrWg=="
+    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -1224,6 +1881,13 @@
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0",
         "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
       }
     },
     "localtunnel": {
@@ -1235,12 +1899,39 @@
         "debug": "2.6.9",
         "openurl": "1.1.1",
         "yargs": "6.6.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.17.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+          "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+          "requires": {
+            "follow-redirects": "^1.2.5",
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lodash-decorators": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash-decorators/-/lodash-decorators-4.5.0.tgz",
+      "integrity": "sha512-isfVBBSzzXu7Z6abY/Bit5hCbM+gPhQx/DluTPAmzUPF3KRtvLLRNBgVFUxw6B8vwTMGyQFRVqbvQBli9hsXZA==",
+      "requires": {
+        "tslib": "^1.7.1"
+      }
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -1276,6 +1967,16 @@
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
     "lodash.create": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
@@ -1286,6 +1987,11 @@
         "lodash._basecreate": "^3.0.0",
         "lodash._isiterateecall": "^3.0.0"
       }
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -1298,6 +2004,31 @@
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.keys": {
       "version": "3.1.2",
@@ -1315,6 +2046,28 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
+    "lodash.padend": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "ltx": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.8.1.tgz",
+      "integrity": "sha512-l4H1FS9I6IVqwvIpUHsSgyxE6t2jP7qd/2MeVG1UhmVK6vlHsQpfm2KNUcbdImeE0ai04vl1qTCF4CPCJqhknQ==",
+      "requires": {
+        "inherits": "^2.0.1"
+      }
+    },
     "md5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
@@ -1323,6 +2076,16 @@
         "charenc": "~0.0.1",
         "crypt": "~0.0.1",
         "is-buffer": "~1.1.1"
+      }
+    },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "media-typer": {
@@ -1356,6 +2119,14 @@
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "requires": {
         "mime-db": "~1.37.0"
+      }
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "^0.1.0"
       }
     },
     "minimatch": {
@@ -1422,14 +2193,87 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mustache": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
-      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
+      "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA=="
     },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "node-forge": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+    },
+    "node-xmpp-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-3.2.0.tgz",
+      "integrity": "sha1-r0Un3wzFq9JpDLohOcwezcgeoYk=",
+      "requires": {
+        "browser-request": "^0.3.3",
+        "debug": "^2.2.0",
+        "md5.js": "^1.3.3",
+        "minimist": "^1.2.0",
+        "node-xmpp-core": "^5.0.9",
+        "request": "^2.65.0",
+        "ws": "^1.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "ws": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+          "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+          "requires": {
+            "options": ">=0.0.5",
+            "ultron": "1.0.x"
+          }
+        }
+      }
+    },
+    "node-xmpp-core": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/node-xmpp-core/-/node-xmpp-core-5.0.9.tgz",
+      "integrity": "sha1-XCjCjtsfs/i+uixnYHd2E/SPNCo=",
+      "requires": {
+        "@xmpp/jid": "^0.0.2",
+        "@xmpp/streamparser": "^0.0.6",
+        "@xmpp/xml": "^0.1.3",
+        "debug": "^2.2.0",
+        "inherits": "^2.0.1",
+        "lodash.assign": "^4.0.0",
+        "node-xmpp-tls-connect": "^1.0.1",
+        "reconnect-core": "https://github.com/dodo/reconnect-core/tarball/merged"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "node-xmpp-tls-connect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-xmpp-tls-connect/-/node-xmpp-tls-connect-1.0.1.tgz",
+      "integrity": "sha1-kazkOsJrE4hhsr5HjfnfGdYdxcM="
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -1487,6 +2331,15 @@
         "lcid": "^1.0.0"
       }
     },
+    "parse-headers": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
+      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+      "requires": {
+        "for-each": "^0.3.2",
+        "trim": "0.0.1"
+      }
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -1527,6 +2380,13 @@
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
       }
     },
     "pathval": {
@@ -1541,9 +2401,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -1558,10 +2418,20 @@
         "pinkie": "^2.0.0"
       }
     },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    "pop-iterate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
+      "integrity": "sha1-zqz9q0q/NT16DyqqLB/Hs/lBO6M="
+    },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+    },
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
     },
     "promise": {
       "version": "7.3.1",
@@ -1569,6 +2439,15 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "~2.0.3"
+      }
+    },
+    "prompts": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-1.2.1.tgz",
+      "integrity": "sha512-GE33SMMVO1ISfnq3i6cE+WYK/tLxRWtZiRkl5vdg0KR0owOCPFOsq8BuFajFbW7b2bMHb8krXaQHOpZyUEuvmA==",
+      "requires": {
+        "kleur": "^3.0.0",
+        "sisteransi": "^1.0.0"
       }
     },
     "proxy-addr": {
@@ -1579,6 +2458,11 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.1.29",
@@ -1591,22 +2475,24 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
-      "integrity": "sha1-TeLmyzspCIyeTLwDv51C+5bOL3U="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
+      "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
+      "requires": {
+        "asap": "^2.0.0",
+        "pop-iterate": "^1.0.1",
+        "weak-map": "^1.0.5"
+      }
+    },
+    "qbox": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/qbox/-/qbox-0.1.7.tgz",
+      "integrity": "sha1-6A8NxdCfhp2IghaMP2asjdKEDwI="
     },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-    },
-    "randomstring": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/randomstring/-/randomstring-1.1.5.tgz",
-      "integrity": "sha1-bfBij3XL1ZMpMNn+OrTpVqGFGMM=",
-      "requires": {
-        "array-uniq": "1.0.2"
-      }
     },
     "range-parser": {
       "version": "1.2.0",
@@ -1644,17 +2530,39 @@
       }
     },
     "readable-stream": {
-      "version": "2.0.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+      "version": "1.0.34",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
       }
+    },
+    "reconnect-core": {
+      "version": "https://github.com/dodo/reconnect-core/tarball/merged",
+      "integrity": "sha512-wZK/v5ZaNaSUs2Wnwh2YSX/Jqv6bQHKNEwojdzV11tByKziR9ikOssf5tvUhx+8/oCBz6AakOFAjZuqPoiRHJQ==",
+      "requires": {
+        "backoff": "~2.3.0"
+      },
+      "dependencies": {
+        "backoff": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
+          "integrity": "sha1-7nx+OAk/kuRyhZ22NedlJFT8Ieo="
+        }
+      }
+    },
+    "reduce-flatten": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "request": {
       "version": "2.88.0",
@@ -1683,6 +2591,16 @@
         "uuid": "^3.3.2"
       }
     },
+    "requestretry": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-3.1.0.tgz",
+      "integrity": "sha512-DkvCPK6qvwxIuVA5TRCvi626WHC2rWjF/n7SCQvVHAr2JX9i1/cmIpSEZlmHAo+c1bj9rjaKoZ9IsKwCpTkoXA==",
+      "requires": {
+        "extend": "^3.0.2",
+        "lodash": "^4.17.10",
+        "when": "^3.7.7"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1693,10 +2611,28 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
+    "retry-axios": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.2.tgz",
+      "integrity": "sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ=="
+    },
+    "rootpath": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/rootpath/-/rootpath-0.1.2.tgz",
+      "integrity": "sha1-Wzeah9ypBum5HWkKWZQ5vvJn6ms="
+    },
     "rsa-pem-from-mod-exp": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
       "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
+    },
+    "rtcpeerconnection-shim": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
+      "integrity": "sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==",
+      "requires": {
+        "sdp": "^2.6.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -1713,10 +2649,20 @@
       "resolved": "https://registry.npmjs.org/scmp/-/scmp-0.0.3.tgz",
       "integrity": "sha1-NkjfLXKUZB5/eGc//CloHZutkHM="
     },
+    "sdp": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.9.0.tgz",
+      "integrity": "sha512-XAVZQO4qsfzVTHorF49zCpkdxiGmPNjA8ps8RcJGtGP3QJ/A8I9/SVg/QnkAFDMXIyGbHZBBFwYBw6WdnhT96w=="
+    },
+    "sdp-transform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.7.0.tgz",
+      "integrity": "sha512-v8/zfKeDKBEXKMf4UT91owHoXM6O+s8gEVtCVSvrAd2eEtuv5u4TKcTXX4a9qrQM3T2Ycr9rLyU+Ww3ZiCiaGQ=="
+    },
     "semver": {
-      "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-      "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "send": {
       "version": "0.16.2",
@@ -1738,6 +2684,14 @@
         "statuses": "~1.4.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -1766,13 +2720,19 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+    "simple-xmpp": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/simple-xmpp/-/simple-xmpp-1.3.0.tgz",
+      "integrity": "sha1-sHfHIVHg9ZKbyak+H+58sihCgss=",
       "requires": {
-        "hoek": "2.x.x"
+        "node-xmpp-client": "^3.0.0",
+        "qbox": "0.1.x"
       }
+    },
+    "sisteransi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+      "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ=="
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -1803,9 +2763,9 @@
       "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
     },
     "sprintf-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "sshpk": {
       "version": "1.15.2",
@@ -1838,20 +2798,10 @@
         "strip-ansi": "^3.0.0"
       }
     },
-    "string.prototype.startswith": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz",
-      "integrity": "sha1-2miYLjU6TprEpDtFCiBF0cRFrns="
-    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "stringstream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -1878,13 +2828,39 @@
         "has-flag": "^1.0.0"
       }
     },
-    "test-value": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-      "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+    "table-layout": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.4.tgz",
+      "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
       "requires": {
-        "array-back": "^1.0.3",
-        "typical": "^2.6.0"
+        "array-back": "^2.0.0",
+        "deep-extend": "~0.6.0",
+        "lodash.padend": "^4.6.1",
+        "typical": "^2.6.1",
+        "wordwrapjs": "^3.0.0"
+      }
+    },
+    "test-value": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
+      "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
+      "requires": {
+        "array-back": "^2.0.0",
+        "typical": "^2.6.1"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "0.6.5",
+      "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "requires": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
       }
     },
     "topo": {
@@ -1911,6 +2887,16 @@
         }
       }
     },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -1925,139 +2911,47 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "twilio": {
-      "version": "2.11.1",
-      "resolved": "http://registry.npmjs.org/twilio/-/twilio-2.11.1.tgz",
-      "integrity": "sha1-RRCZRnMTxWs3Z5lN8tGQYvEO+MQ=",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.25.0.tgz",
+      "integrity": "sha512-4CtYp2MQfz4Z7FQ5KByFc7QwezhaCyF7wPTUznOP83qQGMoLb6zZTXZe7PdqB/J1uG63xVaHqLXVXpe2D46SnA==",
       "requires": {
-        "deprecate": "^0.1.0",
-        "jsonwebtoken": "5.4.x",
-        "q": "0.9.7",
-        "request": "2.74.x",
+        "@types/express": "^4.11.1",
+        "deprecate": "1.0.0",
+        "jsonwebtoken": "^8.1.0",
+        "lodash": "^4.17.10",
+        "moment": "2.19.3",
+        "q": "2.0.x",
+        "request": "^2.87.0",
+        "rootpath": "0.1.2",
         "scmp": "0.0.3",
-        "string.prototype.startswith": "^0.2.0",
-        "underscore": "1.x"
+        "xmlbuilder": "9.0.1"
       },
       "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-        },
-        "form-data": {
-          "version": "1.0.1",
-          "resolved": "http://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
-          "requires": {
-            "async": "^2.0.1",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.11"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "requires": {
-            "chalk": "^1.1.1",
-            "commander": "^2.9.0",
-            "is-my-json-valid": "^2.12.4",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
         "jsonwebtoken": {
-          "version": "5.4.1",
-          "resolved": "http://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.4.1.tgz",
-          "integrity": "sha1-IFXGORlf/lYxT6alHfAkaBhqlpU=",
+          "version": "8.4.0",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz",
+          "integrity": "sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==",
           "requires": {
-            "jws": "^3.0.0",
-            "ms": "^0.7.1"
+            "jws": "^3.1.5",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.1.1"
           }
+        },
+        "moment": {
+          "version": "2.19.3",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
+          "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8="
         },
         "ms": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        },
-        "qs": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-          "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
-        },
-        "request": {
-          "version": "2.74.0",
-          "resolved": "http://registry.npmjs.org/request/-/request-2.74.0.tgz",
-          "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "bl": "~1.1.2",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~1.0.0-rc4",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "node-uuid": "~1.4.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.2.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-          "requires": {
-            "punycode": "^1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -2086,11 +2980,6 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
     },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -2109,10 +2998,15 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
       "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+    },
+    "urlsafe-base64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
+      "integrity": "sha1-I/iQaabGL0bPOh07ABac77kL4MY="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -2156,10 +3050,38 @@
         "wrap-fn": "^0.1.0"
       }
     },
+    "weak-map": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
+      "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes="
+    },
+    "webrtc-adapter": {
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-6.4.8.tgz",
+      "integrity": "sha512-YM8yl545c/JhYcjGHgaCoA7jRK/KZuMwEDFeP2AcP0Auv5awEd+gZE0hXy9z7Ed3p9HvAXp8jdbe+4ESb1zxAw==",
+      "requires": {
+        "rtcpeerconnection-shim": "^1.2.14",
+        "sdp": "^2.9.0"
+      }
+    },
+    "when": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
+      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
+    },
     "which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+    },
+    "wordwrapjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
+      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
+      "requires": {
+        "reduce-flatten": "^1.0.1",
+        "typical": "^2.6.1"
+      }
     },
     "wrap-ansi": {
       "version": "2.1.0",
@@ -2185,13 +3107,17 @@
       "dev": true
     },
     "ws": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
+      "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
       "requires": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
+        "async-limiter": "~1.0.0"
       }
+    },
+    "xmlbuilder": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.1.tgz",
+      "integrity": "sha1-kc1wiXdVNj66V8Et3uq0o0GmH2U="
     },
     "xtend": {
       "version": "4.0.1",
@@ -2202,6 +3128,11 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "6.6.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/tansaku/project_greeter_bot#readme",
   "dependencies": {
-    "botkit": "^0.4.3",
+    "botkit": "^0.6.21",
     "dotenv": "^6.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
manual review still required for some:

```
fixed 7 of 11 vulnerabilities in 685 scanned packages
  2 vulnerabilities required manual review and could not be updated
  1 package update for 2 vulns involved breaking changes
  (use `npm audit fix --force` to install breaking changes; or do it by hand)
```

fixes #31